### PR TITLE
remove deprecated :unneeded flag

### DIFF
--- a/Formula/fusionauth-app.rb
+++ b/Formula/fusionauth-app.rb
@@ -4,8 +4,6 @@ class FusionauthApp < Formula
   url "https://files.fusionauth.io/products/fusionauth/1.34.0/fusionauth-app-1.34.0.zip"
   sha256 "2551288c6ec71bdb2bca0d034f20b495aa22fa4d88a3d8c86b718db45cd95e13"
 
-  bottle :unneeded
-
   def install
     prefix.install "fusionauth-app"
     etc.install "config" => "fusionauth" unless File.exists? etc/"fusionauth"

--- a/Formula/fusionauth-search.rb
+++ b/Formula/fusionauth-search.rb
@@ -4,8 +4,6 @@ class FusionauthSearch < Formula
   url "https://files.fusionauth.io/products/fusionauth/1.34.0/fusionauth-search-1.34.0.zip"
   sha256 "455027921fc988c1af2d82939bde9834fe5e31285ead6d58bd119d0ac9a22e2e"
 
-  bottle :unneeded
-
   def install
     prefix.install "fusionauth-search"
     etc.install "config" => "fusionauth" unless File.exists? etc/"fusionauth"


### PR DESCRIPTION
I ran into a similar warning as documented in issue #4 and tracked at https://github.com/FusionAuth/fusionauth-issues/issues/1465

I previously configured and provisioned the backing postgres database with the `fusionauth/homebrew-fusionauth` tap and wanted to make sure that a fix and reinstallation would act as a "drop-in" replacement, and not muck up anyone's local environment.

To test the change I forked the repo and removed the `bottle :unneeded` flag.

Then, I uninstalled my local copy of the `fusionauth/homebrew-fusionauth` tap:
```
% brew uninstall fusionauth-app
% brew uninstall fusionauth-search
```

Then, I tapped my personal fork of the repo and completed a `brew install`:

```
% brew tap ebahsini/homebrew-fusionauth
% brew install ebahsini/fusionauth/fusionauth-app
% brew install ebahsini/fusionauth/fusionauth-search
```
At this point, the homebrew installation should complete successfully and you shouldn't see any warnings about `unneeded` being deprecated.

Then, startup and test the service:
```
% brew services start ebahsini/fusionauth/fusionauth-app
% brew services start ebahsini/fusionauth/fusionauth-search
```

I can confirm the application completes startup and points at my previously configured postgres db.
