### PR TITLE
fix: undefined method `exists?' for class File

### DIFF
--- a/Formula/fusionauth-app.rb
+++ b/Formula/fusionauth-app.rb
@@ -6,12 +6,13 @@ class FusionauthApp < Formula
 
   def install
     prefix.install "fusionauth-app"
-    etc.install "config" => "fusionauth" unless File.exists? etc / "fusionauth"
-    prefix.install_symlink etc / "fusionauth" => "config"
-    (var / "fusionauth/java").mkpath unless File.exists? var / "fusionauth/java"
-    prefix.install_symlink var / "fusionauth/java"
-    (var / "log/fusionauth").mkpath unless File.exists? var / "log/fusionauth"
-    prefix.install_symlink var / "log/fusionauth" => "logs"
+    etc.install "config" => "fusionauth"
+    (prefix/"config").unlink if (prefix/"config").exist?
+    prefix.install_symlink etc/"fusionauth" => "config"
+    (var/"fusionauth/java").mkpath
+    prefix.install_symlink var/"fusionauth/java"
+    (var/"log/fusionauth").mkpath
+    prefix.install_symlink var/"log/fusionauth" => "logs"
   end
 
   def post_install

--- a/Formula/fusionauth-search.rb
+++ b/Formula/fusionauth-search.rb
@@ -6,13 +6,14 @@ class FusionauthSearch < Formula
 
   def install
     prefix.install "fusionauth-search"
-    etc.install "config" => "fusionauth" unless File.exists? etc/"fusionauth"
+    etc.install "config" => "fusionauth"
+    (prefix/"config").unlink if (prefix/"config").exist?
     prefix.install_symlink etc/"fusionauth" => "config"
-    (var/"log/fusionauth").mkpath unless File.exists? var/"log/fusionauth"
+    (var/"log/fusionauth").mkpath
     prefix.install_symlink var/"log/fusionauth" => "logs"
-    (var/"fusionauth/java").mkpath unless File.exists? var/"fusionauth/java"
+    (var/"fusionauth/java").mkpath
     prefix.install_symlink var/"fusionauth/java"
-    (var/"fusionauth/data").mkpath unless File.exists? var/"fusionauth/data"
+    (var/"fusionauth/data").mkpath
     prefix.install_symlink var/"fusionauth/data"
 
     # Hide all the dylibs from brew


### PR DESCRIPTION
Fixes FusionAuth/homebrew-fusionauth#9

I tested by locally editing the `*.rb` files `/opt/homebrew/Library/Taps/fusionauth/homebrew-fusionauth/Formula`. Installation seemed to work fine with this fix.